### PR TITLE
Adds context hash and translation_key to errors

### DIFF
--- a/lib/json-schema/attribute.rb
+++ b/lib/json-schema/attribute.rb
@@ -10,8 +10,8 @@ module JSON
         "#/#{fragments.join('/')}"
       end
 
-      def self.validation_error(processor, message, fragments, current_schema, failed_attribute, record_errors)
-        error = ValidationError.new(message, fragments, failed_attribute, current_schema)
+      def self.validation_error(processor, message, fragments, current_schema, failed_attribute, record_errors, translation_key, context={})
+        error = ValidationError.new(message, fragments, failed_attribute, current_schema, translation_key, context)
         if record_errors
           processor.validation_error(error)
         else

--- a/lib/json-schema/attributes/additionalitems.rb
+++ b/lib/json-schema/attributes/additionalitems.rb
@@ -13,7 +13,7 @@ module JSON
         when false
           if schema['items'].length < data.length
             message = "The property '#{build_fragment(fragments)}' contains additional array elements outside of the schema when none are allowed"
-            validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+            validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_additional_items', :property => fragments.last)
           end
         when Hash
           additional_items_schema = JSON::Schema.new(schema['additionalItems'], current_schema.uri, validator)

--- a/lib/json-schema/attributes/additionalproperties.rb
+++ b/lib/json-schema/attributes/additionalproperties.rb
@@ -22,7 +22,7 @@ module JSON
 
         if extra_properties.any? && (addprop == false || (addprop.is_a?(Hash) && !addprop.empty?))
           message = "The property '#{build_fragment(fragments)}' contains additional properties #{extra_properties.inspect} outside of the schema when none are allowed"
-          validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+          validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_additional_properties', :additional_properties => extra_properties, :property => fragments.last)
         end
       end
 

--- a/lib/json-schema/attributes/allof.rb
+++ b/lib/json-schema/attributes/allof.rb
@@ -30,7 +30,7 @@ module JSON
 
         if !valid || !errors.empty?
           message = "The property '#{build_fragment(fragments)}' of type #{data.class} did not match all of the required schemas"
-          validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+          validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_did_not_match_all_of', :type => data.class, :property => fragments.last)
           validation_errors(processor).last.sub_errors = errors
         end
       end

--- a/lib/json-schema/attributes/anyof.rb
+++ b/lib/json-schema/attributes/anyof.rb
@@ -38,7 +38,7 @@ module JSON
 
         if !valid
           message = "The property '#{build_fragment(fragments)}' of type #{data.class} did not match one or more of the required schemas"
-          validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+          validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_did_not_match_any_of', :type => data.class, :property => fragments.last)
           validation_errors(processor).last.sub_errors = errors
         end
       end

--- a/lib/json-schema/attributes/dependencies.rb
+++ b/lib/json-schema/attributes/dependencies.rb
@@ -27,7 +27,7 @@ module JSON
       def self.validate_dependency(schema, data, property, value, fragments, processor, attribute, options)
         return if data.key?(value.to_s)
         message = "The property '#{build_fragment(fragments)}' has a property '#{property}' that depends on a missing property '#{value}'"
-        validation_error(processor, message, fragments, schema, attribute, options[:record_errors])
+        validation_error(processor, message, fragments, schema, attribute, options[:record_errors], 'json_schema_error_missing_dependencies', :property => property, :dependency => value)
       end
 
       def self.accept_value?(value)

--- a/lib/json-schema/attributes/divisibleby.rb
+++ b/lib/json-schema/attributes/divisibleby.rb
@@ -12,10 +12,15 @@ module JSON
 
         factor = current_schema.schema[keyword]
 
+        fragment = build_fragment(fragments)
         if factor == 0 || factor == 0.0 || (BigDecimal.new(data.to_s) % BigDecimal.new(factor.to_s)).to_f != 0
-          message = "The property '#{build_fragment(fragments)}' was not divisible by #{factor}"
-          validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+          message = "The property '#{fragment}' was not divisible by #{factor}"
+          validation_error(processor, message, fragments, current_schema, self, options[:record_errors], translation_key, :factor => factor, :property => fragments.last)
         end
+      end
+
+      def self.translation_key
+        "json_schema_error_#{keyword}"
       end
     end
   end

--- a/lib/json-schema/attributes/enum.rb
+++ b/lib/json-schema/attributes/enum.rb
@@ -16,8 +16,9 @@ module JSON
           end
         }.join(', ')
 
-        message = "The property '#{build_fragment(fragments)}' value #{data.inspect} did not match one of the following values: #{values}"
-        validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+        fragment = build_fragment(fragments)
+        message = "The property '#{fragment}' value #{data.inspect} did not match one of the following values: #{values}"
+        validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_enum', :values => values, :property => fragments.last)
       end
     end
   end

--- a/lib/json-schema/attributes/extends.rb
+++ b/lib/json-schema/attributes/extends.rb
@@ -13,10 +13,10 @@ module JSON
             schema.validate(data, fragments, processor, options)
           elsif uri
             message = "The extended schema '#{uri.to_s}' cannot be found"
-            validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+            validation_error(processor, message, fragments, nil, current_schema, self, options[:record_errors], 'json_schema_error_extends_not_found', :property => fragments.last)
           else
             message = "The property '#{build_fragment(fragments)}' was not a valid schema"
-            validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+            validation_error(processor, message, fragments, nil, current_schema, self, options[:record_errors], 'json_schema_error_extends_not_valid', :property => fragments.last)
           end
         end
       end

--- a/lib/json-schema/attributes/formats/custom.rb
+++ b/lib/json-schema/attributes/formats/custom.rb
@@ -13,7 +13,7 @@ module JSON
           @validation_proc.call data
         rescue JSON::Schema::CustomFormatError => e
           message = "The property '#{self.class.build_fragment(fragments)}' #{e.message}"
-          self.class.validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+          self.class.validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_custom_format', :property => fragments.last)
         end
       end
     end

--- a/lib/json-schema/attributes/formats/date.rb
+++ b/lib/json-schema/attributes/formats/date.rb
@@ -8,15 +8,16 @@ module JSON
       def self.validate(current_schema, data, fragments, processor, validator, options = {})
         if data.is_a?(String)
           error_message = "The property '#{build_fragment(fragments)}' must be a date in the format of YYYY-MM-DD"
+          translation_key = 'json_schema_error_date_format'
           if REGEXP.match(data)
             begin
               Date.parse(data)
             rescue ArgumentError => e
               raise e unless e.message == 'invalid date'
-              validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])
+              validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors], translation_key, :property => fragments.last)
             end
           else
-            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])
+            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors], translation_key, :property => fragments.last)
           end
         end
       end

--- a/lib/json-schema/attributes/formats/date_time.rb
+++ b/lib/json-schema/attributes/formats/date_time.rb
@@ -9,6 +9,7 @@ module JSON
         # Timestamp in restricted ISO-8601 YYYY-MM-DDThh:mm:ssZ with optional decimal fraction of the second
         if data.is_a?(String)
           error_message = "The property '#{build_fragment(fragments)}' must be a date/time in the ISO-8601 format of YYYY-MM-DDThh:mm:ssZ or YYYY-MM-DDThh:mm:ss.ssZ"
+          translation_key = 'json_schema_error_date_time_format'
           if (m = REGEXP.match(data))
             parts = data.split("T")
 
@@ -16,16 +17,19 @@ module JSON
               Date.parse(parts[0])
             rescue ArgumentError => e
               raise e unless e.message == 'invalid date'
-              validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])
+              validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors], translation_key, :property => fragments.last)
               return
             end
 
-            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if m.length < 4
-            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if m[1].to_i > 23
-            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if m[2].to_i > 59
-            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if m[3].to_i > 59
+            begin
+              validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors], translation_key, :property => fragments.last) and return if m[1].to_i > 23
+              validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors], translation_key, :property => fragments.last) and return if m[2].to_i > 59
+              validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors], translation_key, :property => fragments.last) and return if m[3].to_i > 59
+            rescue Exception
+              validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors], translation_key, :property => fragments.last)
+            end
           else
-            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])
+            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors], translation_key, :property => fragments.last)
           end
         end
       end

--- a/lib/json-schema/attributes/formats/date_time_v4.rb
+++ b/lib/json-schema/attributes/formats/date_time_v4.rb
@@ -8,7 +8,7 @@ module JSON
         DateTime.rfc3339(data)
       rescue ArgumentError
         error_message = "The property '#{build_fragment(fragments)}' must be a valid RFC3339 date/time string"
-        validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])
+        validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_date_time_format', :property => fragments.last)
       end
     end
   end

--- a/lib/json-schema/attributes/formats/ip.rb
+++ b/lib/json-schema/attributes/formats/ip.rb
@@ -17,7 +17,7 @@ module JSON
         family = ip_version == 6 ? Socket::AF_INET6 : Socket::AF_INET
         unless ip && ip.family == family
           error_message = "The property '#{build_fragment(fragments)}' must be a valid IPv#{ip_version} address"
-          validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])
+          validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_ip_format', :ip_version => ip_version, :property => fragments.last)
         end
       end
 

--- a/lib/json-schema/attributes/formats/time.rb
+++ b/lib/json-schema/attributes/formats/time.rb
@@ -8,12 +8,13 @@ module JSON
       def self.validate(current_schema, data, fragments, processor, validator, options = {})
         if data.is_a?(String)
           error_message = "The property '#{build_fragment(fragments)}' must be a time in the format of hh:mm:ss"
+          translation_key = 'json_schema_error_time_format'
           if (m = REGEXP.match(data))
-            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if m[1].to_i > 23
-            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if m[2].to_i > 59
-            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors]) and return if m[3].to_i > 59
+            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors], translation_key, :property => fragments.last) and return if m[1].to_i > 23
+            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors], translation_key, :property => fragments.last) and return if m[2].to_i > 59
+            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors], translation_key, :property => fragments.last) and return if m[3].to_i > 59
           else
-            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])
+            validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors], translation_key, :property => fragments.last)
           end
         end
       end

--- a/lib/json-schema/attributes/formats/uri.rb
+++ b/lib/json-schema/attributes/formats/uri.rb
@@ -10,7 +10,7 @@ module JSON
         begin
           JSON::Util::URI.parse(data)
         rescue JSON::Schema::UriError
-          validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors])
+          validation_error(processor, error_message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_uri_format', :property => fragments.last)
         end
       end
     end

--- a/lib/json-schema/attributes/limit.rb
+++ b/lib/json-schema/attributes/limit.rb
@@ -7,10 +7,11 @@ module JSON
         schema = current_schema.schema
         return unless data.is_a?(acceptable_type) && invalid?(schema, value(data))
 
-        property    = build_fragment(fragments)
+        fragment    = build_fragment(fragments)
+        property    = fragments.last
         description = error_message(schema)
-        message = format("The property '%s' %s", property, description)
-        validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+        message = format("The property '%s' %s", fragment, description)
+        validation_error(processor, message, fragments, current_schema, self, options[:record_errors], translation_key, :limit => limit(schema), :exclusive => exclusive?(schema), :property => property)
       end
 
       def self.invalid?(schema, data)
@@ -26,6 +27,10 @@ module JSON
 
       def self.limit(schema)
         schema[limit_name]
+      end
+
+      def self.translation_key
+        "json_schema_error_#{limit_name.downcase}"
       end
 
       def self.exclusive?(schema)

--- a/lib/json-schema/attributes/maxdecimal.rb
+++ b/lib/json-schema/attributes/maxdecimal.rb
@@ -10,7 +10,7 @@ module JSON
         s = data.to_s.split(".")[1]
         if s && s.length > max_decimal_places
           message = "The property '#{build_fragment(fragments)}' had more decimal places than the allowed #{max_decimal_places}"
-          validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+          validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_max_decimal', :max_decimal_places => max_decimal_places, :property => fragments.last)
         end
       end
     end

--- a/lib/json-schema/attributes/not.rb
+++ b/lib/json-schema/attributes/not.rb
@@ -3,6 +3,7 @@ require 'json-schema/attribute'
 module JSON
   class Schema
     class NotAttribute < Attribute
+
       def self.validate(current_schema, data, fragments, processor, validator, options = {})
         schema = JSON::Schema.new(current_schema.schema['not'],current_schema.uri,validator)
         failed = true
@@ -22,7 +23,7 @@ module JSON
         end
 
         unless failed
-          validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+          validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_not', :type => data.class, :property => fragments.last)
         end
       end
     end

--- a/lib/json-schema/attributes/oneof.rb
+++ b/lib/json-schema/attributes/oneof.rb
@@ -44,11 +44,13 @@ module JSON
 
         if validation_error_count == one_of.length
           message = "The property '#{build_fragment(fragments)}' of type #{data.class} did not match any of the required schemas"
+          translation_key = 'json_schema_error_one_of_none'
         else
           message = "The property '#{build_fragment(fragments)}' of type #{data.class} matched more than one of the required schemas"
+          translation_key = 'json_schema_error_one_of_too_many'
         end
 
-        validation_error(processor, message, fragments, current_schema, self, options[:record_errors]) if message
+        validation_error(processor, message, fragments, current_schema, self, options[:record_errors], translation_key, :property => fragments.last) if message
         validation_errors(processor).last.sub_errors = errors if message
       end
     end

--- a/lib/json-schema/attributes/pattern.rb
+++ b/lib/json-schema/attributes/pattern.rb
@@ -10,7 +10,7 @@ module JSON
         regexp  = Regexp.new(pattern)
         unless regexp.match(data)
           message = "The property '#{build_fragment(fragments)}' value #{data.inspect} did not match the regex '#{pattern}'"
-          validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+          validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_pattern', :pattern => pattern, :property => fragments.last)
         end
       end
     end

--- a/lib/json-schema/attributes/properties.rb
+++ b/lib/json-schema/attributes/properties.rb
@@ -24,7 +24,7 @@ module JSON
 
           if required?(property_schema, options) && !data.has_key?(property)
             message = "The property '#{build_fragment(fragments)}' did not contain a required property of '#{property}'"
-            validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+            validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_properties_missing', :property => property)
           end
 
           if data.has_key?(property)
@@ -58,7 +58,7 @@ module JSON
         if diff.size > 0
           properties = diff.keys.join(', ')
           message = "The property '#{build_fragment(fragments)}' contained undefined properties: '#{properties}'"
-          validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+          validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_properties_undefined', :properties => properties, :property => properties)
         end
       end
     end

--- a/lib/json-schema/attributes/properties_optional.rb
+++ b/lib/json-schema/attributes/properties_optional.rb
@@ -12,7 +12,7 @@ module JSON
 
           if !property_schema['optional'] && !data.key?(property)
             message = "The property '#{build_fragment(fragments)}' did not contain a required property of '#{property}'"
-            validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+            validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_properties_optional', :property => property)
           end
 
           if data.has_key?(property)

--- a/lib/json-schema/attributes/ref.rb
+++ b/lib/json-schema/attributes/ref.rb
@@ -12,10 +12,10 @@ module JSON
           schema.validate(data, fragments, processor, options)
         elsif uri
           message = "The referenced schema '#{uri.to_s}' cannot be found"
-          validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+          validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_ref_not_found', :property => fragments.last)
         else
           message = "The property '#{build_fragment(fragments)}' was not a valid schema"
-          validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+          validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_ref_not_valid', :property => fragments.last)
         end
       end
 

--- a/lib/json-schema/attributes/required.rb
+++ b/lib/json-schema/attributes/required.rb
@@ -19,7 +19,7 @@ module JSON
 
           if !prop_defaults
             message = "The property '#{build_fragment(fragments)}' did not contain a required property of '#{property}'"
-            validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+            validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_required_property_missing', :property => property)
           end
         end
       end

--- a/lib/json-schema/attributes/type.rb
+++ b/lib/json-schema/attributes/type.rb
@@ -49,18 +49,19 @@ module JSON
           break if valid
         end
 
+        property = fragments.last
         if options[:disallow]
           return if !valid
           message = "The property '#{build_fragment(fragments)}' matched one or more of the following types: #{list_types(types)}"
-          validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+          validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_type_matched_too_many', :types => types, :property => property)
         elsif !valid
           if union
             message = "The property '#{build_fragment(fragments)}' of type #{type_of_data(data)} did not match one or more of the following types: #{list_types(types)}"
-            validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+            validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_type_no_match', :types => types, :property => property)
             validation_errors(processor).last.sub_errors = union_errors
           else
             message = "The property '#{build_fragment(fragments)}' of type #{type_of_data(data)} did not match the following type: #{list_types(types)}"
-            validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+            validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_type_no_match_single', :types => types, :property => property)
           end
         end
       end

--- a/lib/json-schema/attributes/type_v4.rb
+++ b/lib/json-schema/attributes/type_v4.rb
@@ -14,15 +14,25 @@ module JSON
         return if types.any? { |type| data_valid_for_type?(data, type) }
 
         types = types.map { |type| type.is_a?(String) ? type : '(schema)' }.join(', ')
+
+        message, translation_key = if union
+                                     ['one or more of the following types', 'json_schema_error_type_no_match']
+                                   else
+                                     ['the following type', 'json_schema_error_type_no_match_single']
+                                   end
+
+        fragment = build_fragment(fragments)
+        property = fragments.last
+
         message = format(
           "The property '%s' of type %s did not match %s: %s",
-          build_fragment(fragments),
+          fragment,
           data.class,
-          union ? 'one or more of the following types' : 'the following type',
+          message,
           types
         )
 
-        validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+        validation_error(processor, message, fragments, current_schema, self, options[:record_errors], translation_key, :types => types, :property => property)
       end
     end
   end

--- a/lib/json-schema/attributes/uniqueitems.rb
+++ b/lib/json-schema/attributes/uniqueitems.rb
@@ -8,7 +8,7 @@ module JSON
 
         if data.clone.uniq!
           message = "The property '#{build_fragment(fragments)}' contained duplicated array values"
-          validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+          validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'json_schema_error_unique_items', :property => fragments.last)
         end
       end
     end

--- a/lib/json-schema/errors/validation_error.rb
+++ b/lib/json-schema/errors/validation_error.rb
@@ -2,14 +2,16 @@ module JSON
   class Schema
     class ValidationError < StandardError
       INDENT = "    "
-      attr_accessor :fragments, :schema, :failed_attribute, :sub_errors, :message
+      attr_accessor :fragments, :schema, :failed_attribute, :sub_errors, :message, :translation_key, :context
 
-      def initialize(message, fragments, failed_attribute, schema)
+      def initialize(message, fragments, failed_attribute, schema, translation_key, context)
         @fragments = fragments.clone
         @schema = schema
         @sub_errors = {}
         @failed_attribute = failed_attribute
         @message = message
+        @translation_key = translation_key
+        @context = context
         super(message_with_schema)
       end
 
@@ -27,7 +29,14 @@ module JSON
       end
 
       def to_hash
-        base = {:schema => @schema.uri, :fragment => ::JSON::Schema::Attribute.build_fragment(fragments), :message => message_with_schema, :failed_attribute => @failed_attribute.to_s.split(":").last.split("Attribute").first}
+        base = {
+          :schema => @schema.uri,
+          :fragment => ::JSON::Schema::Attribute.build_fragment(fragments),
+          :message => message_with_schema,
+          :failed_attribute => @failed_attribute.to_s.split(":").last.split("Attribute").first,
+          :context => @context,
+          :translation_key => @translation_key
+        }
         if !@sub_errors.empty?
           base[:errors] = @sub_errors.inject({}) do |hsh, (subschema, errors)|
             subschema_sym = subschema.downcase.gsub(/\W+/, '_').to_sym

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -267,6 +267,12 @@ module JSON
         validate!(schema, data, opts.merge(:record_errors => true))
       end
 
+      def fully_validate2(schema, data, opts={})
+        opts[:record_errors] = true
+        validator = JSON::Validator.new(schema, data, opts)
+        validator.validate
+      end
+
       def fully_validate_schema(schema, opts={})
         data = schema
         schema = JSON::Validator.validator_for_name(opts[:version]).metaschema

--- a/test/extended_schema_test.rb
+++ b/test/extended_schema_test.rb
@@ -7,7 +7,7 @@ class ExtendedSchemaTest < Minitest::Test
 
       if data & current_schema.schema['bitwise-and'].to_i == 0
         message = "The property '#{build_fragment(fragments)}' did not evaluate to true when bitwise-AND'd with #{current_schema.schema['bitwise-and']}"
-        validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+        validation_error(processor, message, fragments, current_schema, self, options[:record_errors], 'exteded_schema_test')
       end
     end
   end

--- a/test/support/test_helper.rb
+++ b/test/support/test_helper.rb
@@ -29,6 +29,7 @@ class Minitest::Test
 
   def assert_valid(schema, data, options = {}, msg = "#{data.inspect} should be valid for schema:\n#{schema.inspect}")
     errors = validation_errors(schema, data, options)
+
     assert_equal([], errors, msg)
   end
 


### PR DESCRIPTION
The context hash contains additional information pertaining to the error.
Of primary concern is the property value which generally refers to the specific json object property that is failing validation.
All errors now also return a translation key prefixed with 'json_schema_error_'.  These are intended to be used with a translation library like I18n.